### PR TITLE
AQI pipeline fixes: bronze flattening, silver sub-index, and gold ranking refactor

### DIFF
--- a/dags/aqi_backfill_dag.py
+++ b/dags/aqi_backfill_dag.py
@@ -1,12 +1,17 @@
-"""Backfill DAG: fetch historical OGD AQI data."""
+"""Backfill DAG: fetch historical OGD AQI data and build Medallion layers."""
 from datetime import datetime, timedelta
+from pathlib import Path
 
 from airflow import DAG
 from airflow.providers.standard.operators.python import PythonOperator
+from airflow.providers.standard.operators.bash import BashOperator
+from airflow.providers.snowflake.operators.snowflake import SQLExecuteQueryOperator
 import sys
 
 sys.path.insert(0, '/opt/airflow/include/scripts')
 from fetch_ogd import fetch_and_upload_ogd
+
+COPY_INTO_BRONZE_SQL = Path('/opt/airflow/include/sql/copy_into_bronze.sql').read_text(encoding='utf-8')
 
 default_args = {
     "owner": "data-engineering",
@@ -18,7 +23,7 @@ default_args = {
 dag = DAG(
     "aqi_backfill_pipeline",
     default_args=default_args,
-    description="Backfill historical OGD AQI data to S3 bronze",
+    description="Backfill historical OGD AQI data: API -> S3 -> Snowflake -> dbt (Silver -> Gold)",
     schedule=None,  # Manual trigger only
     catchup=False,
     tags=["aqi", "backfill", "ingestion"],
@@ -27,7 +32,7 @@ dag = DAG(
 
 def fetch_ogd_backfill_task(limit=1000, offset=0, **context):
     """Fetch OGD data in batches for backfill."""
-    result = fetch_and_upload_ogd(limit=limit, offset=offset)
+    result = fetch_and_upload_ogd(limit=limit, offset=offset, paginate=True)
     context["task_instance"].xcom_push(key="s3_key", value=result["s3_key"])
     context["task_instance"].xcom_push(key="record_count", value=result["records_uploaded"])
     return result
@@ -42,3 +47,37 @@ fetch_backfill = PythonOperator(
     },
     dag=dag,
 )
+
+copy_into_bronze = SQLExecuteQueryOperator(
+    task_id='copy_into_bronze',
+    conn_id='snowflake_default',
+    sql=COPY_INTO_BRONZE_SQL,
+    database='aqi_db',
+    dag=dag,
+)
+
+dbt_run_silver = BashOperator(
+    task_id='dbt_run_silver',
+    bash_command='cd /opt/airflow/dbt && dbt run --select silver --profiles-dir .',
+    dag=dag,
+)
+
+dbt_run_gold = BashOperator(
+    task_id='dbt_run_gold',
+    bash_command='cd /opt/airflow/dbt && dbt run --select gold --profiles-dir .',
+    dag=dag,
+)
+
+dbt_test = BashOperator(
+    task_id='dbt_test',
+    bash_command='cd /opt/airflow/dbt && dbt test --profiles-dir .',
+    dag=dag,
+)
+
+log_completion = BashOperator(
+    task_id='log_completion',
+    bash_command='echo "Backfill pipeline complete at $(date)."',
+    dag=dag,
+)
+
+fetch_backfill >> copy_into_bronze >> dbt_run_silver >> dbt_run_gold >> dbt_test >> log_completion

--- a/dbt/models/gold/gold_aqi_rankings.sql
+++ b/dbt/models/gold/gold_aqi_rankings.sql
@@ -1,5 +1,19 @@
 {{ config(materialized='table') }}
 
+WITH anchor AS (
+    SELECT MAX(measurement_date) AS max_measurement_date
+    FROM {{ ref('gold_city_aqi_daily') }}
+    WHERE pollutant = 'PM2.5'
+),
+
+recent_pm25 AS (
+    SELECT d.*
+    FROM {{ ref('gold_city_aqi_daily') }} d
+    CROSS JOIN anchor a
+    WHERE d.pollutant = 'PM2.5'
+      AND d.measurement_date >= DATEADD('day', -7, a.max_measurement_date)
+)
+
 SELECT
     city,
     state,
@@ -7,8 +21,6 @@ SELECT
     RANK() OVER (ORDER BY AVG(avg_value) DESC) AS pollution_rank,
     MODE(dominant_category) AS typical_category,
     CURRENT_TIMESTAMP() AS dbt_updated_at
-FROM {{ ref('gold_city_aqi_daily') }}
-WHERE measurement_date >= DATEADD('day', -7, CURRENT_DATE())
-  AND pollutant = 'PM2.5'
+FROM recent_pm25
 GROUP BY 1, 2
 ORDER BY pollution_rank

--- a/dbt/models/gold/gold_aqi_rankings.sql
+++ b/dbt/models/gold/gold_aqi_rankings.sql
@@ -1,26 +1,78 @@
 {{ config(materialized='table') }}
 
 WITH anchor AS (
-    SELECT MAX(measurement_date) AS max_measurement_date
-    FROM {{ ref('gold_city_aqi_daily') }}
-    WHERE pollutant = 'PM2.5'
+    SELECT MAX(DATE(measured_at)) AS max_measurement_date
+    FROM {{ ref('silver_aqi_measurements') }}
 ),
 
-recent_pm25 AS (
-    SELECT d.*
-    FROM {{ ref('gold_city_aqi_daily') }} d
+recent_silver AS (
+    SELECT
+        city,
+        state,
+        DATE(measured_at) AS measurement_date,
+        pollutant,
+        sub_index
+    FROM {{ ref('silver_aqi_measurements') }} s
     CROSS JOIN anchor a
-    WHERE d.pollutant = 'PM2.5'
-      AND d.measurement_date >= DATEADD('day', -7, a.max_measurement_date)
+    WHERE DATE(s.measured_at) >= DATEADD('day', -7, a.max_measurement_date)
+      AND s.sub_index IS NOT NULL
+),
+
+daily_pollutant AS (
+    SELECT
+        city,
+        state,
+        measurement_date,
+        pollutant,
+        AVG(sub_index) AS pollutant_subindex_daily
+    FROM recent_silver
+    GROUP BY 1, 2, 3, 4
+),
+
+daily_city_aqi AS (
+    SELECT
+        city,
+        state,
+        measurement_date,
+        pollutant AS dominant_pollutant,
+        ROUND(pollutant_subindex_daily, 2) AS daily_composite_aqi
+    FROM daily_pollutant
+    QUALIFY ROW_NUMBER() OVER (
+        PARTITION BY city, state, measurement_date
+        ORDER BY pollutant_subindex_daily DESC NULLS LAST
+    ) = 1
+),
+
+ranked AS (
+    SELECT
+        city,
+        state,
+        ROUND(AVG(daily_composite_aqi), 2) AS composite_aqi_7d,
+        ROUND(MAX(daily_composite_aqi), 2) AS peak_aqi_7d,
+        MODE(dominant_pollutant) AS dominant_pollutant_7d,
+        MODE(
+            CASE
+                WHEN daily_composite_aqi <= 50 THEN 'Good'
+                WHEN daily_composite_aqi <= 100 THEN 'Moderate'
+                WHEN daily_composite_aqi <= 200 THEN 'Poor'
+                WHEN daily_composite_aqi <= 300 THEN 'Very Poor'
+                WHEN daily_composite_aqi <= 400 THEN 'Severe'
+                ELSE 'Severe+'
+            END
+        ) AS typical_category,
+        CURRENT_TIMESTAMP() AS dbt_updated_at
+    FROM daily_city_aqi
+    GROUP BY 1, 2
 )
 
 SELECT
     city,
     state,
-    ROUND(AVG(avg_value), 2) AS week_avg_pm25,
-    RANK() OVER (ORDER BY AVG(avg_value) DESC) AS pollution_rank,
-    MODE(dominant_category) AS typical_category,
-    CURRENT_TIMESTAMP() AS dbt_updated_at
-FROM recent_pm25
-GROUP BY 1, 2
+    composite_aqi_7d,
+    peak_aqi_7d,
+    dominant_pollutant_7d,
+    RANK() OVER (ORDER BY composite_aqi_7d DESC, peak_aqi_7d DESC) AS pollution_rank,
+    typical_category,
+    dbt_updated_at
+FROM ranked
 ORDER BY pollution_rank

--- a/dbt/models/silver/silver_aqi_measurements.sql
+++ b/dbt/models/silver/silver_aqi_measurements.sql
@@ -7,7 +7,10 @@
 WITH source AS (
     SELECT * FROM {{ source('bronze', 'AQI_MEASUREMENTS') }}
     {% if is_incremental() %}
-    WHERE LOAD_TIMESTAMP > (SELECT MAX(LOAD_TIMESTAMP) FROM {{ this }})
+    WHERE LOAD_TIMESTAMP > (
+        SELECT COALESCE(MAX(LOAD_TIMESTAMP), TO_TIMESTAMP_NTZ('1900-01-01'))
+        FROM {{ this }}
+    )
     {% endif %}
 ),
 
@@ -24,15 +27,18 @@ cleaned AS (
         TRIM(UPPER(COALESCE(RAW_DATA:state::VARCHAR, 'UNKNOWN'))) AS state,
         RAW_DATA:station::VARCHAR AS station_id,
         RAW_DATA:station::VARCHAR AS station_name,
-        TRIM(UPPER(RAW_DATA:pollutant_id::VARCHAR)) AS pollutant,
-        CAST(RAW_DATA:pollutant_avg::FLOAT AS FLOAT) AS value,
-        TO_TIMESTAMP_NTZ(RAW_DATA:last_update::VARCHAR) AS measured_at,
-        RAW_DATA:latitude::FLOAT AS latitude,
-        RAW_DATA:longitude::FLOAT AS longitude,
+                TRIM(UPPER(COALESCE(RAW_DATA:pollutant_id::VARCHAR, RAW_DATA:pollutant::VARCHAR))) AS pollutant,
+                TRY_TO_DOUBLE(RAW_DATA:pollutant_avg::VARCHAR) AS value,
+                COALESCE(
+                    TRY_TO_TIMESTAMP_NTZ(RAW_DATA:last_update::VARCHAR, 'DD-MM-YYYY HH24:MI:SS'),
+                    TRY_TO_TIMESTAMP_NTZ(RAW_DATA:last_update::VARCHAR)
+                ) AS measured_at,
+                TRY_TO_DOUBLE(RAW_DATA:latitude::VARCHAR) AS latitude,
+                TRY_TO_DOUBLE(RAW_DATA:longitude::VARCHAR) AS longitude,
         LOAD_TIMESTAMP
     FROM source
-    WHERE RAW_DATA:pollutant_avg::FLOAT IS NOT NULL
-      AND RAW_DATA:pollutant_avg::FLOAT >= 0
+        WHERE TRY_TO_DOUBLE(RAW_DATA:pollutant_avg::VARCHAR) IS NOT NULL
+            AND TRY_TO_DOUBLE(RAW_DATA:pollutant_avg::VARCHAR) >= 0
       AND RAW_DATA:last_update::VARCHAR IS NOT NULL
 ),
 

--- a/dbt/models/silver/silver_aqi_measurements.sql
+++ b/dbt/models/silver/silver_aqi_measurements.sql
@@ -42,30 +42,98 @@ cleaned AS (
       AND RAW_DATA:last_update::VARCHAR IS NOT NULL
 ),
 
-aqi_category AS (
-    SELECT *,
+subindex AS (
+    SELECT
+        *,
         CASE
             WHEN pollutant = 'PM2.5' THEN
                 CASE
-                    WHEN value <= 12.0 THEN 'Good'
-                    WHEN value <= 35.4 THEN 'Moderate'
-                    WHEN value <= 55.4 THEN 'Unhealthy for Sensitive Groups'
-                    WHEN value <= 150.4 THEN 'Unhealthy'
-                    WHEN value <= 250.4 THEN 'Very Unhealthy'
-                    ELSE 'Hazardous'
+                    WHEN value <= 30 THEN (50 / 30) * value
+                    WHEN value <= 60 THEN ((100 - 51) / (60 - 31)) * (value - 31) + 51
+                    WHEN value <= 90 THEN ((200 - 101) / (90 - 61)) * (value - 61) + 101
+                    WHEN value <= 120 THEN ((300 - 201) / (120 - 91)) * (value - 91) + 201
+                    WHEN value <= 250 THEN ((400 - 301) / (250 - 121)) * (value - 121) + 301
+                    WHEN value <= 500 THEN ((500 - 401) / (500 - 251)) * (value - 251) + 401
+                    ELSE 500
                 END
             WHEN pollutant = 'PM10' THEN
                 CASE
-                    WHEN value <= 54 THEN 'Good'
-                    WHEN value <= 154 THEN 'Moderate'
-                    WHEN value <= 254 THEN 'Unhealthy for Sensitive Groups'
-                    WHEN value <= 354 THEN 'Unhealthy'
-                    WHEN value <= 424 THEN 'Very Unhealthy'
-                    ELSE 'Hazardous'
+                    WHEN value <= 50 THEN (50 / 50) * value
+                    WHEN value <= 100 THEN ((100 - 51) / (100 - 51)) * (value - 51) + 51
+                    WHEN value <= 250 THEN ((200 - 101) / (250 - 101)) * (value - 101) + 101
+                    WHEN value <= 350 THEN ((300 - 201) / (350 - 251)) * (value - 251) + 201
+                    WHEN value <= 430 THEN ((400 - 301) / (430 - 351)) * (value - 351) + 301
+                    WHEN value <= 600 THEN ((500 - 401) / (600 - 431)) * (value - 431) + 401
+                    ELSE 500
                 END
-            ELSE 'N/A'
-        END AS aqi_category
+            WHEN pollutant = 'NO2' THEN
+                CASE
+                    WHEN value <= 40 THEN (50 / 40) * value
+                    WHEN value <= 80 THEN ((100 - 51) / (80 - 41)) * (value - 41) + 51
+                    WHEN value <= 180 THEN ((200 - 101) / (180 - 81)) * (value - 81) + 101
+                    WHEN value <= 280 THEN ((300 - 201) / (280 - 181)) * (value - 181) + 201
+                    WHEN value <= 400 THEN ((400 - 301) / (400 - 281)) * (value - 281) + 301
+                    WHEN value <= 1000 THEN ((500 - 401) / (1000 - 401)) * (value - 401) + 401
+                    ELSE 500
+                END
+            WHEN pollutant = 'SO2' THEN
+                CASE
+                    WHEN value <= 40 THEN (50 / 40) * value
+                    WHEN value <= 80 THEN ((100 - 51) / (80 - 41)) * (value - 41) + 51
+                    WHEN value <= 380 THEN ((200 - 101) / (380 - 81)) * (value - 81) + 101
+                    WHEN value <= 800 THEN ((300 - 201) / (800 - 381)) * (value - 381) + 201
+                    WHEN value <= 1600 THEN ((400 - 301) / (1600 - 801)) * (value - 801) + 301
+                    WHEN value <= 2000 THEN ((500 - 401) / (2000 - 1601)) * (value - 1601) + 401
+                    ELSE 500
+                END
+            WHEN pollutant = 'CO' THEN
+                CASE
+                    WHEN value <= 1 THEN (50 / 1) * value
+                    WHEN value <= 2 THEN ((100 - 51) / (2 - 1.1)) * (value - 1.1) + 51
+                    WHEN value <= 10 THEN ((200 - 101) / (10 - 2.1)) * (value - 2.1) + 101
+                    WHEN value <= 17 THEN ((300 - 201) / (17 - 10.1)) * (value - 10.1) + 201
+                    WHEN value <= 34 THEN ((400 - 301) / (34 - 17.1)) * (value - 17.1) + 301
+                    WHEN value <= 50 THEN ((500 - 401) / (50 - 34.1)) * (value - 34.1) + 401
+                    ELSE 500
+                END
+            WHEN pollutant = 'OZONE' THEN
+                CASE
+                    WHEN value <= 50 THEN (50 / 50) * value
+                    WHEN value <= 100 THEN ((100 - 51) / (100 - 51)) * (value - 51) + 51
+                    WHEN value <= 168 THEN ((200 - 101) / (168 - 101)) * (value - 101) + 101
+                    WHEN value <= 208 THEN ((300 - 201) / (208 - 169)) * (value - 169) + 201
+                    WHEN value <= 748 THEN ((400 - 301) / (748 - 209)) * (value - 209) + 301
+                    WHEN value <= 1000 THEN ((500 - 401) / (1000 - 749)) * (value - 749) + 401
+                    ELSE 500
+                END
+            WHEN pollutant = 'NH3' THEN
+                CASE
+                    WHEN value <= 200 THEN (50 / 200) * value
+                    WHEN value <= 400 THEN ((100 - 51) / (400 - 201)) * (value - 201) + 51
+                    WHEN value <= 800 THEN ((200 - 101) / (800 - 401)) * (value - 401) + 101
+                    WHEN value <= 1200 THEN ((300 - 201) / (1200 - 801)) * (value - 801) + 201
+                    WHEN value <= 1800 THEN ((400 - 301) / (1800 - 1201)) * (value - 1201) + 301
+                    WHEN value <= 2000 THEN ((500 - 401) / (2000 - 1801)) * (value - 1801) + 401
+                    ELSE 500
+                END
+            ELSE NULL
+        END AS sub_index
     FROM cleaned
+),
+
+final AS (
+    SELECT
+        *,
+        CASE
+            WHEN sub_index <= 50 THEN 'Good'
+            WHEN sub_index <= 100 THEN 'Moderate'
+            WHEN sub_index <= 200 THEN 'Poor'
+            WHEN sub_index <= 300 THEN 'Very Poor'
+            WHEN sub_index <= 400 THEN 'Severe'
+            WHEN sub_index IS NULL THEN 'N/A'
+            ELSE 'Severe+'
+        END AS aqi_category
+    FROM subindex
 )
 
-SELECT * FROM aqi_category
+SELECT * FROM final

--- a/dbt/models/silver/silver_aqi_measurements.yml
+++ b/dbt/models/silver/silver_aqi_measurements.yml
@@ -16,3 +16,9 @@ models:
       - name: measured_at
         tests:
           - not_null
+      - name: sub_index
+        description: Pollutant-level AQI sub-index using CPCB breakpoint formulas.
+        tests:
+          - not_null:
+              config:
+                where: "pollutant in ('PM2.5', 'PM10', 'NO2', 'SO2', 'CO', 'OZONE', 'NH3')"

--- a/dbt/models/silver/silver_aqi_measurements.yml
+++ b/dbt/models/silver/silver_aqi_measurements.yml
@@ -13,3 +13,6 @@ models:
       - name: pollutant
         tests:
           - not_null
+      - name: measured_at
+        tests:
+          - not_null

--- a/include/scripts/fetch_ogd.py
+++ b/include/scripts/fetch_ogd.py
@@ -142,7 +142,11 @@ def run_ingestion(
     return s3_key, len(records)
 
 
-def fetch_and_upload_ogd(limit: int | None = None, offset: int | None = None) -> dict[str, Any]:
+def fetch_and_upload_ogd(
+    limit: int | None = None,
+    offset: int | None = None,
+    paginate: bool = False,
+) -> dict[str, Any]:
     """Compatibility wrapper for DAG/tests expecting a dict payload."""
     effective_limit = limit if limit is not None else 100
     effective_offset = offset if offset is not None else 0
@@ -150,7 +154,7 @@ def fetch_and_upload_ogd(limit: int | None = None, offset: int | None = None) ->
     s3_key, record_count = run_ingestion(
         limit=effective_limit,
         offset=effective_offset,
-        paginate=False,
+        paginate=paginate,
     )
     return {
         "status": "success",

--- a/include/sql/copy_into_bronze.sql
+++ b/include/sql/copy_into_bronze.sql
@@ -4,13 +4,14 @@
 
 USE SCHEMA aqi_db.bronze;
 
--- Load raw JSON from S3 into VARIANT column
+-- Load one row per AQI reading from payload.records[] into VARIANT column
 COPY INTO aqi_db.bronze.AQI_MEASUREMENTS (RAW_DATA, FILE_NAME)
 FROM (
   SELECT
-    $1 AS RAW_DATA,
+    record.value AS RAW_DATA,
     METADATA$FILENAME AS FILE_NAME
-  FROM @aqi_db.bronze.s3_aqi_stage
+  FROM @aqi_db.bronze.s3_aqi_stage,
+       LATERAL FLATTEN(INPUT => $1:records) AS record
 )
 FILE_FORMAT = (TYPE = 'JSON')
 ON_ERROR = 'CONTINUE'

--- a/include/sql/copy_into_bronze.sql
+++ b/include/sql/copy_into_bronze.sql
@@ -4,16 +4,17 @@
 
 USE SCHEMA aqi_db.bronze;
 
--- Load one row per AQI reading from payload.records[] into VARIANT column
+-- Load one row per AQI reading from payload.records[] into VARIANT column.
+-- Stage aliasing avoids identifier issues with FLATTEN in COPY SELECT transforms.
 COPY INTO aqi_db.bronze.AQI_MEASUREMENTS (RAW_DATA, FILE_NAME)
 FROM (
   SELECT
-    record.value AS RAW_DATA,
-    METADATA$FILENAME AS FILE_NAME
-  FROM @aqi_db.bronze.s3_aqi_stage,
-       LATERAL FLATTEN(INPUT => $1:records) AS record
+    rec.value AS RAW_DATA,
+    src.METADATA$FILENAME AS FILE_NAME
+  FROM @aqi_db.bronze.s3_aqi_stage
+    (FILE_FORMAT => aqi_db.bronze.jsonl_format) AS src,
+    LATERAL FLATTEN(INPUT => src.$1:records) AS rec
 )
-FILE_FORMAT = (TYPE = 'JSON')
 ON_ERROR = 'CONTINUE'
 PURGE = FALSE;
 


### PR DESCRIPTION
## Summary
This PR merges validated AQI pipeline fixes into `main`.

### Included changes
- Fix Bronze COPY logic to flatten `records[]` into one row per AQI reading.
- Complete backfill DAG flow (fetch -> bronze -> silver -> gold -> tests).
- Harden Silver parsing:
  - null-safe incremental cutoff
  - robust timestamp parsing (`DD-MM-YYYY HH24:MI:SS` with fallback)
  - safe numeric parsing via `TRY_TO_DOUBLE`
- Move AQI sub-index/business logic to Silver layer.
- Simplify Gold ranking model to aggregation/ranking only from Silver `sub_index`.
- Add Silver tests for `measured_at` and `sub_index`.

### Validation performed
- dbt run --select silver_aqi_measurements --full-refresh
- dbt run --select gold_aqi_rankings
- dbt test
- Verified non-empty Snowflake outputs for silver/gold layers.

### Branch note
`feature_kirtan` push is blocked by GitHub Push Protection due old unrelated history containing secret patterns.  
`feature_kirtan_clean` is the safe merge branch with only required validated fixes.